### PR TITLE
Support multiple services in auth-provider

### DIFF
--- a/app/connectors/AuthProviderClient.scala
+++ b/app/connectors/AuthProviderClient.scala
@@ -33,7 +33,7 @@ object AuthProviderClient extends AuthProviderClient {
   sealed class TokenEmailPairInvalidException() extends Exception
 }
 
-trait AuthProviderClient extends WSHttp {
+trait AuthProviderClient {
 
   sealed abstract class UserRole(val name: String)
 
@@ -41,10 +41,12 @@ trait AuthProviderClient extends WSHttp {
 
   case object ServiceManagerRole extends UserRole("service-manager")
 
+  val ServiceName = "fasttrack"
+
   import config.MicroserviceAppConfig.userManagementConfig._
 
   def candidatesReport(implicit hc: HeaderCarrier): Future[List[Candidate]] =
-    GET(s"$url/candidates").map { response =>
+    WSHttp.GET(s"$url/service/$ServiceName/findByRole/${CandidateRole.name}").map { response =>
       if (response.status == OK) {
         response.json.as[List[Candidate]]
       } else {
@@ -54,14 +56,14 @@ trait AuthProviderClient extends WSHttp {
 
   def addUser(email: String, password: String, firstName: String,
     lastName: String, role: UserRole)(implicit hc: HeaderCarrier): Future[UserResponse] =
-    POST(s"$url/add", AddUserRequest(email.toLowerCase, password, firstName, lastName, role.name)).map { response =>
+    WSHttp.POST(s"$url/add", AddUserRequest(email.toLowerCase, password, firstName, lastName, role.name, ServiceName)).map { response =>
       response.json.as[UserResponse]
     }.recover {
       case Upstream4xxResponse(_, 409, _, _) => throw new EmailTakenException()
     }
 
   def removeAllUsers()(implicit hc: HeaderCarrier): Future[Unit] =
-    GET(s"$url/test-commands/remove-all").map { response =>
+    WSHttp.GET(s"$url/test-commands/remove-all").map { response =>
       if (response.status == OK) {
         ()
       } else {
@@ -70,7 +72,7 @@ trait AuthProviderClient extends WSHttp {
     }
 
   def getToken(email: String)(implicit hc: HeaderCarrier): Future[String] =
-    GET(s"$url/auth-code/$email").map { response =>
+    WSHttp.GET(s"$url/auth-code/$ServiceName/$email").map { response =>
       if (response.status == OK) {
         response.body
       } else {
@@ -79,7 +81,7 @@ trait AuthProviderClient extends WSHttp {
     }
 
   def activate(email: String, token: String)(implicit hc: HeaderCarrier): Future[Unit] =
-    POST(s"$url/activate", ActivateEmailRequest(email.toLowerCase, token)).map(_ => (): Unit)
+    WSHttp.POST(s"$url/activate", ActivateEmailRequest(ServiceName, email.toLowerCase, token)).map(_ => (): Unit)
       .recover {
         case Upstream4xxResponse(_, 410, _, _) => throw new TokenExpiredException()
         case e: NotFoundException => throw new TokenEmailPairInvalidException()

--- a/app/connectors/ExchangeObjects.scala
+++ b/app/connectors/ExchangeObjects.scala
@@ -43,10 +43,10 @@ object ExchangeObjects {
 
   case class AllocationDetails(location: String, venueDescription: String, attendanceDateTime: DateTime, expirationDate: Option[LocalDate])
 
-  case class AddUserRequest(email: String, password: String, firstName: String, lastName: String, role: String)
+  case class AddUserRequest(email: String, password: String, firstName: String, lastName: String, role: String, service: String)
   case class UserResponse(firstName: String, lastName: String, preferredName: Option[String],
     isActive: Boolean, userId: UUID, email: String, lockStatus: String, role: String)
-  case class ActivateEmailRequest(email: String, token: String)
+  case class ActivateEmailRequest(service: String, email: String, token: String)
 
   object Implicits {
     implicit val userEmailFormat = Json.format[UserEmail]


### PR DESCRIPTION
- Stop AuthProviderClient extending WSHttp, this seemed like overkill and it was confusing IntelliJ.
- At the same time, update it to work with new contract changes in Auth Provider to support multiple services (ahead of CSR Faststream)