### PR TITLE
NO_JIRA: Bump old assessment centres to 2017 and dev assessment centres to 2018

### DIFF
--- a/conf/assessment-centres-prod.yaml
+++ b/conf/assessment-centres-prod.yaml
@@ -2,655 +2,655 @@ London:
   - London (Berkeley House):
       description: Berkeley House
       capacities:
-         - date: 24/05/16
+         - date: 24/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/16
+         - date: 26/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/16
+         - date: 31/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/06/16
+         - date: 06/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/16
+         - date: 07/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/16
+         - date: 08/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/16
+         - date: 09/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 1:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/16
+         - date: 05/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/16
+         - date: 06/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/16
+         - date: 09/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/16
+         - date: 10/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/16
+         - date: 12/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 2:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/16
+         - date: 05/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/16
+         - date: 06/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/16
+         - date: 09/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/16
+         - date: 10/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/16
+         - date: 12/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 3:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 4:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 5:
       description: FSAC
       capacities:
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -658,40 +658,40 @@ Edinburgh:
   - Edinburgh:
       description: Saughton House
       capacities:
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -699,82 +699,82 @@ Bristol:
   - Bristol (Crescent Centre) 2:
       description: The Cresent Centre
       capacities:
-         - date: 09/06/16
+         - date: 09/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/16
+         - date: 15/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/16
+         - date: 22/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
   - Bristol (Learning Centre) 1:
       description: The Cresent Centre
       capacities:
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/16
+         - date: 31/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/16
+         - date: 14/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/16
+         - date: 18/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/16
+         - date: 21/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/16
+         - date: 25/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/16
+         - date: 26/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -782,94 +782,94 @@ Manchester:
   - Manchester:
       description: Civil Justice Centre
       capacities:
-         - date: 05/05/16
+         - date: 05/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/05/16
+         - date: 24/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/16
+         - date: 07/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/16
+         - date: 08/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/16
+         - date: 29/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/16
+         - date: 18/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/16
+         - date: 19/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/16
+         - date: 20/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/16
+         - date: 21/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/16
+         - date: 22/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/16
+         - date: 25/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/16
+         - date: 26/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -877,79 +877,79 @@ Newcastle:
   - Newcastle Job Centre:
       description: Cathedral Square Jobcentre
       capacities:
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/16
+         - date: 28/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/16
+         - date: 29/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
   - Newcastle Longbenton:
       description: Longbenton
       capacities:
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/16
+         - date: 08/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -957,76 +957,76 @@ Nottingham:
   - Nottingham (Fitzroy House):
       description: Fitzroy House
       capacities:
-         - date: 31/05/16
+         - date: 31/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/16
+         - date: 08/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
   - Nottingham (The Axis):
       description: The Axis
       capacities:
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/16
+         - date: 28/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/16
+         - date: 29/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -1034,37 +1034,37 @@ Glasgow:
   - Glasgow:
       description: Shettleston Jobcentre
       capacities:
-         - date: 24/05/16
+         - date: 24/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/16
+         - date: 26/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/16
+         - date: 07/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/16
+         - date: 08/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/16
+         - date: 09/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
      
@@ -1072,118 +1072,117 @@ Leeds:
   - Leeds (Quarry House) 1:
       description: Quarry House
       capacities:
-         - date: 10/05/16
+         - date: 10/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/16
+         - date: 12/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/16
+         - date: 26/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/06/16
+         - date: 21/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/06/16
+         - date: 27/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/16
+         - date: 14/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/16
+         - date: 15/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/16
+         - date: 18/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/16
+         - date: 19/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/16
+         - date: 20/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/16
+         - date: 21/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/16
+         - date: 22/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/16
+         - date: 25/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/16
+         - date: 26/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/16
+         - date: 08/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
-     

--- a/conf/assessment-centres.yaml
+++ b/conf/assessment-centres.yaml
@@ -2,655 +2,655 @@ London:
   - London (Berkeley House):
       description: Berkeley House
       capacities:
-         - date: 24/05/17
+         - date: 24/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/17
+         - date: 26/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/17
+         - date: 31/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/06/17
+         - date: 06/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/17
+         - date: 07/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/17
+         - date: 08/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/17
+         - date: 09/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 1:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/17
+         - date: 05/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/17
+         - date: 06/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/17
+         - date: 09/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/17
+         - date: 10/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/17
+         - date: 12/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 2:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/17
+         - date: 05/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/17
+         - date: 06/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/17
+         - date: 09/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/17
+         - date: 10/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/17
+         - date: 12/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 3:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 4:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 5:
       description: FSAC
       capacities:
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -658,40 +658,40 @@ Edinburgh:
   - Edinburgh:
       description: Saughton House
       capacities:
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -699,82 +699,82 @@ Bristol:
   - Bristol (Crescent Centre) 2:
       description: The Cresent Centre
       capacities:
-         - date: 09/06/17
+         - date: 09/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/17
+         - date: 15/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/17
+         - date: 22/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
   - Bristol (Learning Centre) 1:
       description: The Cresent Centre
       capacities:
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/17
+         - date: 31/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/17
+         - date: 14/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/17
+         - date: 18/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/17
+         - date: 21/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/17
+         - date: 25/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/17
+         - date: 26/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -782,94 +782,94 @@ Manchester:
   - Manchester:
       description: Civil Justice Centre
       capacities:
-         - date: 05/05/17
+         - date: 05/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/05/17
+         - date: 24/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/17
+         - date: 07/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/17
+         - date: 08/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/17
+         - date: 29/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/17
+         - date: 18/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/17
+         - date: 19/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/17
+         - date: 20/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/17
+         - date: 21/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/17
+         - date: 22/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/17
+         - date: 25/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/17
+         - date: 26/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -877,79 +877,79 @@ Newcastle:
   - Newcastle Job Centre:
       description: Cathedral Square Jobcentre
       capacities:
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/17
+         - date: 28/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/17
+         - date: 29/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
   - Newcastle Longbenton:
       description: Longbenton
       capacities:
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/17
+         - date: 08/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -957,76 +957,76 @@ Nottingham:
   - Nottingham (Fitzroy House):
       description: Fitzroy House
       capacities:
-         - date: 31/05/17
+         - date: 31/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/17
+         - date: 08/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
   - Nottingham (The Axis):
       description: The Axis
       capacities:
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/17
+         - date: 28/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/17
+         - date: 29/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -1034,37 +1034,37 @@ Glasgow:
   - Glasgow:
       description: Shettleston Jobcentre
       capacities:
-         - date: 24/05/17
+         - date: 24/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/17
+         - date: 26/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/17
+         - date: 07/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/17
+         - date: 08/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/17
+         - date: 09/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
      
@@ -1072,118 +1072,117 @@ Leeds:
   - Leeds (Quarry House) 1:
       description: Quarry House
       capacities:
-         - date: 10/05/17
+         - date: 10/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/17
+         - date: 12/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/17
+         - date: 26/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/06/17
+         - date: 21/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/06/17
+         - date: 27/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/17
+         - date: 14/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/17
+         - date: 15/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/17
+         - date: 18/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/17
+         - date: 19/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/17
+         - date: 20/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/17
+         - date: 21/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/17
+         - date: 22/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/17
+         - date: 25/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/17
+         - date: 26/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/17
+         - date: 08/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
-     

--- a/it/repositories/AssessmentCentreYamlRepositorySpec.scala
+++ b/it/repositories/AssessmentCentreYamlRepositorySpec.scala
@@ -70,7 +70,7 @@ class AssessmentCentreYamlRepositorySpec extends IntegrationSpec with MockitoSug
       val capacityDate = venue.capacityDates.head
       capacityDate.amCapacity must be(6)
       capacityDate.pmCapacity must be(6)
-      capacityDate.date.toString(DateFormat) must be("24/5/17")
+      capacityDate.date.toString(DateFormat) must be("24/5/18")
     }
 
     "reject invalid configuration" in {
@@ -121,7 +121,7 @@ class AssessmentCentreYamlRepositorySpec extends IntegrationSpec with MockitoSug
       val venue = assessmentCapacity.venues(1)
       venue.venueName must be("London (FSAC) 1")
       venue.venueDescription must be ("FSAC")
-      val capacityDate = venue.capacityDates.find(_.date == new LocalDate("2016-07-04")).get
+      val capacityDate = venue.capacityDates.find(_.date == new LocalDate("2017-07-04")).get
       capacityDate.amCapacity must be(6)
       capacityDate.pmCapacity must be(6)
     }

--- a/it/repositories/LocationsSchemesJsonRepositorySpec.scala
+++ b/it/repositories/LocationsSchemesJsonRepositorySpec.scala
@@ -69,7 +69,7 @@ class LocationsSchemesJsonRepositorySpec extends IntegrationSpec with MockitoSug
       val capacityDate = venue.capacityDates.head
       capacityDate.amCapacity must be(6)
       capacityDate.pmCapacity must be(6)
-      capacityDate.date.toString(DateFormat) must be("24/5/17")
+      capacityDate.date.toString(DateFormat) must be("24/5/18")
     }
 
     "reject invalid configuration" in {
@@ -120,7 +120,7 @@ class LocationsSchemesJsonRepositorySpec extends IntegrationSpec with MockitoSug
       val venue = assessmentCapacity.venues(1)
       venue.venueName must be("London (FSAC) 1")
       venue.venueDescription must be ("FSAC")
-      val capacityDate = venue.capacityDates.find(_.date == new LocalDate("2016-07-04")).get
+      val capacityDate = venue.capacityDates.find(_.date == new LocalDate("2017-07-04")).get
       capacityDate.amCapacity must be(6)
       capacityDate.pmCapacity must be(6)
     }


### PR DESCRIPTION
There is no ticket for this, but currently we can't follow through the whole journey because assessment centre dates are in the past. This keeps things working until we receive the new assessment schedules