### PR TITLE
Reinitialise indexes after wiping the database

### DIFF
--- a/app/repositories/package.scala
+++ b/app/repositories/package.scala
@@ -62,26 +62,30 @@ package object repositories {
   lazy val schoolsRepository = SchoolsCSVRepository
   lazy val prevYearCandidatesDetailsRepository = new PreviousYearCandidatesDetailsMongoRepository()
 
+  def initIndexes = {
+    Future.sequence(List(
+      onlineTestPDFReportRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending)), unique = true)),
+      applicationRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending), ("userId", Ascending)), unique = true)),
+      applicationRepository.collection.indexesManager.create(Index(Seq(("userId", Ascending), ("frameworkId", Ascending)), unique = true)),
+      onlineTestRepository.collection.indexesManager.create(Index(Seq(("online-tests.token", Ascending)), unique = false)),
+      onlineTestRepository.collection.indexesManager.create(Index(Seq(("applicationStatus", Ascending)), unique = false)),
+      onlineTestRepository.collection.indexesManager.create(Index(Seq(("online-tests.invitationDate", Ascending)), unique = false)),
+
+      contactDetailsRepository.collection.indexesManager.create(Index(Seq(("userId", Ascending)), unique = true)),
+      passMarkSettingsRepository.collection.indexesManager.create(Index(Seq(("createDate", Ascending)), unique = true)),
+
+      assessmentCentrePassMarkSettingsRepository.collection.indexesManager.create(Index(Seq(("info.createDate", Ascending)), unique = true)),
+
+      applicationAssessmentRepository.collection.indexesManager.create(Index(Seq(("venue", Ascending), ("date", Ascending),
+        ("session", Ascending), ("slot", Ascending)), unique = true)),
+      applicationAssessmentRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending)), unique = true)),
+
+      applicationAssessmentScoresRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending)), unique = true))
+    ))
+  }
+
   /** Create indexes */
-  Await.result(Future.sequence(List(
-    onlineTestPDFReportRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending)), unique = true)),
-    applicationRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending), ("userId", Ascending)), unique = true)),
-    applicationRepository.collection.indexesManager.create(Index(Seq(("userId", Ascending), ("frameworkId", Ascending)), unique = true)),
-    onlineTestRepository.collection.indexesManager.create(Index(Seq(("online-tests.token", Ascending)), unique = false)),
-    onlineTestRepository.collection.indexesManager.create(Index(Seq(("applicationStatus", Ascending)), unique = false)),
-    onlineTestRepository.collection.indexesManager.create(Index(Seq(("online-tests.invitationDate", Ascending)), unique = false)),
-
-    contactDetailsRepository.collection.indexesManager.create(Index(Seq(("userId", Ascending)), unique = true)),
-    passMarkSettingsRepository.collection.indexesManager.create(Index(Seq(("createDate", Ascending)), unique = true)),
-
-    assessmentCentrePassMarkSettingsRepository.collection.indexesManager.create(Index(Seq(("info.createDate", Ascending)), unique = true)),
-
-    applicationAssessmentRepository.collection.indexesManager.create(Index(Seq(("venue", Ascending), ("date", Ascending),
-      ("session", Ascending), ("slot", Ascending)), unique = true)),
-    applicationAssessmentRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending)), unique = true)),
-
-    applicationAssessmentScoresRepository.collection.indexesManager.create(Index(Seq(("applicationId", Ascending)), unique = true))
-  )), 20 seconds)
+  Await.result(initIndexes, 20 seconds)
 
   implicit object BSONDateTimeHandler extends BSONHandler[BSONDateTime, DateTime] {
     def read(time: BSONDateTime) = new DateTime(time.value, DateTimeZone.UTC)

--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -37,6 +37,7 @@ trait TestDataGeneratorService {
   def clearDatabase()(implicit hc: HeaderCarrier): Future[Unit] = {
     for {
       _ <- MongoDbConnection.mongoConnector.db().drop()
+      _ <- repositories.initIndexes
       _ <- AuthProviderClient.removeAllUsers()
       _ <- RegisteredStatusGenerator.createUser(generationId = 1,
         firstName = "Service", lastName = "Manager", email = "test_service_manager_1@mailinator.com",


### PR DESCRIPTION
I believe this will fix startup issues on deployment at the moment where somehow we've inserted data that defies our indexes (i'm assuming indexes get removed when QA wipe the database as part of their BAU)

Handily, this should also highlight the point at which we're inserting this inconsistent data, and make that easier to find and fix too.