### PR TITLE
FSET-1525 Fix for passmark modelling report

### DIFF
--- a/app/controllers/ReportingController.scala
+++ b/app/controllers/ReportingController.scala
@@ -28,6 +28,7 @@ import model.Scheme.Scheme
 import model.persisted.SchemeEvaluationResult
 import model.report.{ AssessmentCentreScoresReportItem, DiversityReportItem, PassMarkReportItem }
 import model.{ ApplicationStatusOrder, ApplicationStatuses, AssessmentExercise, ProgressStatuses, UniqueIdentifier }
+import model.ApplicationStatuses.AssessmentScoresAccepted
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.Json
 import play.api.libs.streams.Streams
@@ -224,7 +225,12 @@ trait ReportingController extends BaseController {
           assessmentCentreIndicatorRepository.calculateIndicator(contactDetails.postCode).assessmentCentre
         }
         val onlineTestResults = data.allTestResults.getOrElse(appId.toString(), passMarkResultsEmpty)
-        val assessmentScores = data.allAssessmentScores.get(appId.toString())
+
+        val assessmentScores = if(application.progress.contains(AssessmentScoresAccepted.toString.toLowerCase())) {
+          data.allAssessmentScores.get(appId.toString())
+        } else {
+          None
+        }
 
         val schemeOnlineTestResults = processEvaluations(appId, application.schemes, data.allPassMarkEvaluations)
         val assessmentCentreTestResults = processEvaluations(appId, application.schemes, data.allAssessmentCentreEvaluations)


### PR DESCRIPTION
Fix so that the pass mark modelling report does not include assessment scores that have been saved by the qa but not accepted