### PR TITLE
FSET-2048 fix data endpoint to correct candidate's application status

### DIFF
--- a/app/controllers/FixDataController.scala
+++ b/app/controllers/FixDataController.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.play.microservice.controller.BaseController
 import services.FixDataService
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object FixDataController extends FixDataController(FixDataService)
 
@@ -71,4 +70,7 @@ abstract class FixDataController(fixDataService: FixDataService) extends BaseCon
     fixDataService.emailAdminWithdrawnApplicationNotEmailed(applicationId).map(_ => Ok)
   }
 
+  def setAssessmentCentrePassedNotified(applicationId: String): Action[AnyContent] = Action.async { implicit request =>
+    fixDataService.setAssessmentCentrePassedNotified(applicationId).map(_ => Ok)
+  }
 }

--- a/app/services/FixDataService.scala
+++ b/app/services/FixDataService.scala
@@ -135,4 +135,10 @@ trait FixDataService {
   def removeCollection(name: String): Future[Unit] = {
     appRepo.removeCollection(name)
   }
+
+  def setAssessmentCentrePassedNotified(applicationId: String)(implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = {
+    for {
+      _ <- appRepo.updateStatus(applicationId, ApplicationStatuses.AssessmentCentrePassedNotified)
+    } yield ()
+  }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -123,9 +123,10 @@ GET         /fixdata/fixNoDateScoresAndFeedback                          control
 GET         /fixdata/forcePassmarkReevaluationForOnlineTestComplete      controllers.FixDataController.forcePassmarkReevaluationForOnlineTestComplete(applicationId: String)
 GET         /fixdata/assignCandidateToLondonAssessmentCentre             controllers.AssessmentCentreIndicatorController.assignCandidateToLondonAssessmentCentre(applicationId: String)
 
-GET         /fixdata/findAdminWithdrawnApplicationsNotEmailed                   controllers.FixDataController.findAdminWithdrawnApplicationsNotEmailed
-GET         /fixdata/emailAdminWithdrawnApplicationNotEmailed                   controllers.FixDataController.emailAdminWithdrawnApplicationNotEmailed(applicationId: String)
+GET         /fixdata/findAdminWithdrawnApplicationsNotEmailed            controllers.FixDataController.findAdminWithdrawnApplicationsNotEmailed
+GET         /fixdata/emailAdminWithdrawnApplicationNotEmailed            controllers.FixDataController.emailAdminWithdrawnApplicationNotEmailed(applicationId: String)
 
+GET         /fixdata/setAssessmentCentrePassedNotified                   controllers.FixDataController.setAssessmentCentrePassedNotified(applicationId: String)
 
 GET         /campaign-reset/listCollections                              controllers.FixDataController.listCollections
 GET         /campaign-reset/removeCollection                             controllers.FixDataController.removeCollection(name: String)


### PR DESCRIPTION
fix data endpoint to correct candidate's application status where the progress status is ASSESSMENT_CENTRE_PASSED_NOTIFIED